### PR TITLE
Format ATs consistently (fix jenkins gradle builds that depend on forge)

### DIFF
--- a/src/main/resources/forge_at.cfg
+++ b/src/main/resources/forge_at.cfg
@@ -251,34 +251,34 @@ protected net.minecraft.client.gui.FontRenderer func_78277_a(CZ)F # renderUnicod
 
 # ChunkProviderServer
 # ChunkProviderEnd
-private-f net/minecraft/world/gen/ChunkProviderEnd/field_185969_i #lperlin1
-private-f net/minecraft/world/gen/ChunkProviderEnd/field_185970_j #lperlin2
-private-f net/minecraft/world/gen/ChunkProviderEnd/field_185971_k #perlin
-private-f net/minecraft/world/gen/ChunkProviderEnd/field_185973_o #island
+private-f net.minecraft.world.gen.ChunkProviderEnd field_185969_i #lperlin1
+private-f net.minecraft.world.gen.ChunkProviderEnd field_185970_j #lperlin2
+private-f net.minecraft.world.gen.ChunkProviderEnd field_185971_k #perlin
+private-f net.minecraft.world.gen.ChunkProviderEnd field_185973_o #island
 
 # ChunkProviderOverworld
-private-f net/minecraft/world/gen/ChunkProviderOverworld/field_185991_j #lperlin1
-private-f net/minecraft/world/gen/ChunkProviderOverworld/field_185992_k #lperlin2
-private-f net/minecraft/world/gen/ChunkProviderOverworld/field_185993_l #perlin
-private-f net/minecraft/world/gen/ChunkProviderOverworld/field_185994_m #surface
-private-f net/minecraft/world/gen/ChunkProviderOverworld/field_185979_A #ravineGenerator
-private-f net/minecraft/world/gen/ChunkProviderOverworld/field_185980_B #oceanMonumentGenerator
-private-f net/minecraft/world/gen/ChunkProviderOverworld/field_186003_v #caveGenerator
-private-f net/minecraft/world/gen/ChunkProviderOverworld/field_186004_w #strongholdGenerator
-private-f net/minecraft/world/gen/ChunkProviderOverworld/field_186005_x #villageGenerator
-private-f net/minecraft/world/gen/ChunkProviderOverworld/field_186006_y #mineshaftGenerator
-private-f net/minecraft/world/gen/ChunkProviderOverworld/field_186007_z #scatteredFeatureGenerator
+private-f net.minecraft.world.gen.ChunkProviderOverworld field_185991_j #lperlin1
+private-f net.minecraft.world.gen.ChunkProviderOverworld field_185992_k #lperlin2
+private-f net.minecraft.world.gen.ChunkProviderOverworld field_185993_l #perlin
+private-f net.minecraft.world.gen.ChunkProviderOverworld field_185994_m #surface
+private-f net.minecraft.world.gen.ChunkProviderOverworld field_185979_A #ravineGenerator
+private-f net.minecraft.world.gen.ChunkProviderOverworld field_185980_B #oceanMonumentGenerator
+private-f net.minecraft.world.gen.ChunkProviderOverworld field_186003_v #caveGenerator
+private-f net.minecraft.world.gen.ChunkProviderOverworld field_186004_w #strongholdGenerator
+private-f net.minecraft.world.gen.ChunkProviderOverworld field_186005_x #villageGenerator
+private-f net.minecraft.world.gen.ChunkProviderOverworld field_186006_y #mineshaftGenerator
+private-f net.minecraft.world.gen.ChunkProviderOverworld field_186007_z #scatteredFeatureGenerator
 
 # ChunkProviderHell
-private-f net/minecraft/world/gen/ChunkProviderHell/field_185957_u #lperlin1
-private-f net/minecraft/world/gen/ChunkProviderHell/field_185958_v #lperlin2
-private-f net/minecraft/world/gen/ChunkProviderHell/field_185959_w #perlin
-private-f net/minecraft/world/gen/ChunkProviderHell/field_73177_m #perlin2
-private-f net/minecraft/world/gen/ChunkProviderHell/field_73174_n #perlin3
-public-f net/minecraft/world/gen/ChunkProviderHell/field_185946_g #scale
-public-f net/minecraft/world/gen/ChunkProviderHell/field_185947_h #depth
-private-f net/minecraft/world/gen/ChunkProviderHell/field_185939_I #netherCaveGenerator
-private-f net/minecraft/world/gen/ChunkProviderHell/field_73172_c #netherBridgeGenerator
+private-f net.minecraft.world.gen.ChunkProviderHell field_185957_u #lperlin1
+private-f net.minecraft.world.gen.ChunkProviderHell field_185958_v #lperlin2
+private-f net.minecraft.world.gen.ChunkProviderHell field_185959_w #perlin
+private-f net.minecraft.world.gen.ChunkProviderHell field_73177_m #perlin2
+private-f net.minecraft.world.gen.ChunkProviderHell field_73174_n #perlin3
+public-f net.minecraft.world.gen.ChunkProviderHell field_185946_g #scale
+public-f net.minecraft.world.gen.ChunkProviderHell field_185947_h #depth
+private-f net.minecraft.world.gen.ChunkProviderHell field_185939_I #netherCaveGenerator
+private-f net.minecraft.world.gen.ChunkProviderHell field_73172_c #netherBridgeGenerator
 
 # PlayerManager
 private-f net.minecraft.server.management.PlayerManager$PlayerInstance field_187285_e # field_187285_e


### PR DESCRIPTION
Try to fix the jenkins builds that depend on forge 1.9
It works locally but I have no way to test on Jenkins besides PRing here.